### PR TITLE
Import requests ConnectionError in web modules

### DIFF
--- a/modules/web/crawler.py
+++ b/modules/web/crawler.py
@@ -2,6 +2,7 @@ from bs4 import BeautifulSoup
 from modules.random_user_agent import random_user_agent
 from requests import get
 from requests import packages
+from requests.exceptions import ConnectionError
 
 
 packages.urllib3.disable_warnings()

--- a/modules/web/lfi.py
+++ b/modules/web/lfi.py
@@ -1,6 +1,7 @@
 from threading import main_thread
 from requests import get
 from requests import packages
+from requests.exceptions import ConnectionError
 
 
 packages.urllib3.disable_warnings()

--- a/modules/web/sqli.py
+++ b/modules/web/sqli.py
@@ -1,5 +1,6 @@
 from requests import get
 from requests import packages
+from requests.exceptions import ConnectionError
 
 
 packages.urllib3.disable_warnings()

--- a/modules/web/xss.py
+++ b/modules/web/xss.py
@@ -3,6 +3,7 @@ from string import ascii_letters
 
 from requests import get
 from requests import packages
+from requests.exceptions import ConnectionError
 
 
 packages.urllib3.disable_warnings()


### PR DESCRIPTION
## Summary
- Import `ConnectionError` from `requests.exceptions` in web LFI, SQLi, XSS, and crawler modules
- Ensure existing exception handlers use the imported name for network failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896517c48c0832db1f8073a294d1fb1