### PR TITLE
Remove unused main_thread import from LFI module

### DIFF
--- a/modules/web/lfi.py
+++ b/modules/web/lfi.py
@@ -1,4 +1,3 @@
-from threading import main_thread
 from requests import get
 from requests import packages
 


### PR DESCRIPTION
## Summary
- remove unused `main_thread` import from the LFI web module

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896518232f0832da715a55ba9327264