### PR TITLE
Remove duplicate platform import

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -15,7 +15,6 @@ from re import search
 from socket import AF_INET, SOCK_DGRAM, socket
 from subprocess import DEVNULL, PIPE, CalledProcessError, Popen, check_call
 from sys import platform as sys_platform
-from platform import platform
 
 from requests import get
 from rich.text import Text


### PR DESCRIPTION
## Summary
- streamline utils import list by removing a redundant `platform` import

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689651826f8c832dbed385ec9ca83c35