### PR TITLE
Fix typo in SQLi module logging message

### DIFF
--- a/modules/web/sqli.py
+++ b/modules/web/sqli.py
@@ -39,7 +39,7 @@ class TestSQLI:
                 response = get(test_url, verify=False)
             except ConnectionError:
                 self.log.logger(
-                    "errro", f"Connection error raised on: {test_url}, skipping"
+                    "error", f"Connection error raised on: {test_url}, skipping"
                 )
             else:
                 for error in self.sql_dbms_errors:


### PR DESCRIPTION
## Summary
- Correct logging level string from `errro` to `error` in SQL injection tester

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68965183af2c832d83702f96f6ab2035