### PR TITLE
Log exception details when parsing API response

### DIFF
--- a/modules/getexploits.py
+++ b/modules/getexploits.py
@@ -41,7 +41,7 @@ def GetExploitInfo(CVEID, log) -> list[ExploitInfo]:
         )
         return []
     except Exception as e:
-        log.logger("error", f"An error occured while parsing API response.")
+        log.logger("error", f"An error occured while parsing API response: {e}")
         return []
     else:
         ExploitInfos = []


### PR DESCRIPTION
## Summary
- log API parsing errors with exception details

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896518acbd8832d8bc44f3773e0ab1d