### PR TITLE
Add timeouts to HTTP requests

### DIFF
--- a/modules/getexploits.py
+++ b/modules/getexploits.py
@@ -32,6 +32,7 @@ def GetExploitInfo(CVEID, log) -> list[ExploitInfo]:
                 "X-Requested-With": "XMLHttpRequest",
                 "User-Agent": next(random_user_agent(log)),
             },
+            timeout=10,
         ).json()
     except ConnectionError:
         log.logger(
@@ -71,6 +72,7 @@ def GetExploitContents(ExploitLink, log) -> tuple:
                 "X-Requested-With": "XMLHttpRequest",
                 "User-Agent": user_agent,
             },
+            timeout=10,
         )
         content = apiresponse.content
         filename = apiresponse.headers["Content-Disposition"].lstrip(

--- a/modules/web/crawler.py
+++ b/modules/web/crawler.py
@@ -11,7 +11,12 @@ def crawl(target_url, log) -> set[str]:
         target_url += "/"
 
     try:
-        get(target_url, headers={"User-Agent": next(random_user_agent(log))}, verify=False)
+        get(
+            target_url,
+            headers={"User-Agent": next(random_user_agent(log))},
+            verify=False,
+            timeout=10,
+        )
     except ConnectionError:
         log.logger("error", f"Connection error raised.")
         return set()
@@ -38,7 +43,12 @@ def link_finder(target_url, log) -> set[str]:
 
     urls = set()
 
-    reqs = get(target_url, headers={"User-Agent": next(random_user_agent(log))}, verify=False)
+    reqs = get(
+        target_url,
+        headers={"User-Agent": next(random_user_agent(log))},
+        verify=False,
+        timeout=10,
+    )
     soup = BeautifulSoup(reqs.text, "html.parser")
     for link in soup.find_all("a", href=True):
         url = link["href"]

--- a/modules/web/dirbust.py
+++ b/modules/web/dirbust.py
@@ -7,7 +7,7 @@ from requests import packages
 
 packages.urllib3.disable_warnings()
 
-def dirbust(target_url, console, log) -> None:
+def dirbust(target_url, console, log, timeout=10) -> None:
     if not target_url.endswith("/"):
         target_url += "/"
 
@@ -30,7 +30,7 @@ def dirbust(target_url, console, log) -> None:
         headers = {"User-Agent": next(random_user_agent(log))}
 
         try:
-            req = get(test_url, headers=headers, verify=False)
+            req = get(test_url, headers=headers, verify=False, timeout=timeout)
         except Exception as e:
             log.logger("error", e)
         else:

--- a/modules/web/lfi.py
+++ b/modules/web/lfi.py
@@ -77,7 +77,7 @@ class TestLFI:
                     continue
 
                 try:
-                    response = get(test_url, verify=False)
+                    response = get(test_url, verify=False, timeout=10)
                 except ConnectionError:
                     self.log.logger(
                         "error", f"Connection error raised on: {test_url}, skipping"

--- a/modules/web/sqli.py
+++ b/modules/web/sqli.py
@@ -36,7 +36,7 @@ class TestSQLI:
                 continue
 
             try:
-                response = get(test_url, verify=False)
+                response = get(test_url, verify=False, timeout=10)
             except ConnectionError:
                 self.log.logger(
                     "errro", f"Connection error raised on: {test_url}, skipping"

--- a/modules/web/webvuln.py
+++ b/modules/web/webvuln.py
@@ -54,7 +54,7 @@ def webvuln(target, log, console) -> None:
 
     banner(f"Testing web application on {target} ...", "purple", console)
 
-    dirbust(target_url, console, log)
+    dirbust(target_url, console, log, timeout=10)
 
     for url in testable_urls:
         LFI.test_lfi(url)

--- a/modules/web/xss.py
+++ b/modules/web/xss.py
@@ -56,7 +56,7 @@ class TestXSS:
                     continue
 
                 try:
-                    response = get(test_url, verify=False)
+                    response = get(test_url, verify=False, timeout=10)
                 except ConnectionError:
                     self.log.logger(
                         "error", f"Connection error raised on: {test_url}, skipping"


### PR DESCRIPTION
## Summary
- prevent indefinite hangs by adding timeout to exploit-db API requests
- add timeout handling to crawler, dirbuster, and vulnerability tests
- propagate timeout through webvuln dirbust call

## Testing
- `python -m py_compile modules/getexploits.py modules/web/crawler.py modules/web/dirbust.py modules/web/lfi.py modules/web/sqli.py modules/web/xss.py modules/web/webvuln.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896518b8e90832db4763c481cd3c47f