### PR TITLE
Add comprehensive test suite for utility, API, logging and reporting

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# ensure project root is on sys.path
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+import pytest
+
+from api import AutoScanner
+
+
+def test_create_scan_args_basic(monkeypatch):
+    scanner = AutoScanner()
+    args = scanner.CreateScanArgs(100, 3, False, None)
+    assert "--host-timeout 100" in args
+    assert "-T 3" in args
+    assert "-sV" in args
+
+
+def test_create_scan_args_os_scan_requires_root(monkeypatch):
+    scanner = AutoScanner()
+    monkeypatch.setattr("api.is_root", lambda: False)
+    with pytest.raises(Exception):
+        scanner.CreateScanArgs(None, None, True, None)
+
+
+def test_init_host_info_missing_fields():
+    scanner = AutoScanner()
+    info = scanner.InitHostInfo({})
+    assert info == {
+        "mac": "Unknown",
+        "vendor": "Unknown",
+        "os_name": "Unknown",
+        "os_accuracy": "Unknown",
+        "os_type": "Unknown",
+    }
+
+
+def test_parse_vuln_info():
+    scanner = AutoScanner()
+    vuln = SimpleNamespace(
+        description="desc",
+        severity="high",
+        severity_score=9.0,
+        details_url="url",
+        exploitability="exploit",
+    )
+    info = scanner.ParseVulnInfo(vuln)
+    assert info["description"] == "desc"
+    assert info["severity_score"] == 9.0
+
+
+def test_scan_with_mocks(monkeypatch):
+    scanner = AutoScanner()
+    # mock PortScanner
+    class FakeScanner:
+        def scan(self, hosts, arguments):
+            pass
+
+        def __getitem__(self, host):
+            return {
+                "tcp": {80: {"product": "nginx", "version": "1.0"}},
+                "addresses": {"mac": "aa"},
+                "vendor": ["vendor"],
+                "osmatch": [{"name": "Linux", "accuracy": "100", "osclass": [{"type": "os"}]}],
+            }
+
+    monkeypatch.setattr("api.PortScanner", lambda: FakeScanner())
+    monkeypatch.setattr("api.GenerateKeyword", lambda p, v: "nginx 1.0")
+
+    class FakeVuln(SimpleNamespace):
+        CVEID = "CVE-1"
+
+    monkeypatch.setattr("api.searchCVE", lambda keyword, log, api: [FakeVuln(description="d", severity="s", severity_score=1, details_url="u", exploitability="e")])
+    result = scanner.scan("127.0.0.1", scan_vulns=True)
+    assert "127.0.0.1" in result
+    assert result["127.0.0.1"]["ports"][80]["product"] == "nginx"
+    assert "nginx" in result["127.0.0.1"]["vulns"]

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,25 @@
+import logging
+
+from rich.console import Console
+
+from modules.logger import Logger, banner
+
+
+def test_banner_prints_without_error():
+    console = Console(record=True)
+    banner("msg", "red", console)
+    assert console.export_text().strip() != ""
+
+
+def test_logger_levels(monkeypatch):
+    console = Console(record=True)
+    logger = Logger(console)
+
+    records = []
+
+    def fake_info(msg):
+        records.append(msg)
+
+    monkeypatch.setattr(logger.log, "info", fake_info)
+    logger.logger("info", "hello")
+    assert any("hello" in r for r in records)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,58 @@
+from types import SimpleNamespace
+
+import pytest
+
+from modules.report import (
+    InitializeReport,
+    InitializeWebhookReport,
+    ReportMail,
+    ReportType,
+    SendWebhook,
+)
+
+
+class DummyLog:
+    def __init__(self):
+        self.messages = []
+
+    def logger(self, level, message):
+        self.messages.append((level, message))
+
+
+class DummyConsole:
+    def save_text(self, filename):
+        with open(filename, "w", encoding="utf-8") as f:
+            f.write("log")
+
+    def save_html(self, filename):
+        with open(filename, "w", encoding="utf-8") as f:
+            f.write("<html></html>")
+
+
+def test_initialize_report_calls_email(monkeypatch):
+    called = {}
+
+    def fake_email(obj, log, console):
+        called["email"] = True
+
+    monkeypatch.setattr("modules.report.InitializeEmailReport", fake_email)
+    log = DummyLog()
+    console = DummyConsole()
+    email_obj = ReportMail("a", "b", "c", "d", "e", 1)
+    InitializeReport(ReportType.EMAIL, email_obj, log, console)
+    assert called.get("email")
+
+
+def test_send_webhook_success(monkeypatch, tmp_path):
+    class Resp:
+        status_code = 200
+
+    def fake_post(url, files):
+        return Resp()
+
+    monkeypatch.setattr("modules.report.post", fake_post)
+    log = DummyLog()
+    (tmp_path / "report.log").write_text("data")
+    monkeypatch.chdir(tmp_path)
+    SendWebhook("http://example.com", log)
+    assert ("success", "Webhook report sent succesfully.") in log.messages

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,156 @@
+import os
+from types import SimpleNamespace
+
+import pytest
+from rich.console import Console
+
+from modules import utils
+from modules.utils import (
+    ScanMode,
+    ScanType,
+    InitArgsAPI,
+    InitArgsScanType,
+    InitArgsTarget,
+    InitArgsMode,
+    InitReport,
+    Confirmation,
+    UserConfirmation,
+    GetHostsToScan,
+    SaveOutput,
+    get_terminal_width,
+)
+
+
+class DummyLog:
+    def __init__(self):
+        self.messages = []
+
+    def logger(self, level, message):
+        self.messages.append((level, message))
+
+
+@pytest.fixture
+def log():
+    return DummyLog()
+
+
+@pytest.fixture(autouse=True)
+def cleanup(tmp_path, monkeypatch):
+    # ensure we run in temporary directory for file-based tests
+    monkeypatch.chdir(tmp_path)
+    yield
+
+
+def create_args(**kwargs):
+    defaults = dict(
+        api=None,
+        scan_type=None,
+        target=None,
+        host_file=None,
+        mode="normal",
+        yes_please=False,
+        report=None,
+        report_email=None,
+        report_email_password=None,
+        report_email_to=None,
+        report_email_from=None,
+        report_email_server=None,
+        report_email_server_port=None,
+        report_webhook=None,
+        speed=3,
+        host_timeout=240,
+        nmap_flags="",
+    )
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+def test_initargsapi_reads_file(log):
+    with open("api.txt", "w", encoding="utf-8") as f:
+        f.write("KEY\n")
+    args = create_args()
+    key = InitArgsAPI(args, log)
+    assert key == "KEY"
+
+
+def test_initargsscantype_arp_when_root(monkeypatch, log):
+    args = create_args(scan_type="arp")
+    monkeypatch.setattr(utils, "is_root", lambda: True)
+    result = InitArgsScanType(args, log)
+    assert result is ScanType.ARP
+
+
+def test_initargsscantype_ping_when_not_root(monkeypatch, log):
+    args = create_args(scan_type="arp")
+    monkeypatch.setattr(utils, "is_root", lambda: False)
+    result = InitArgsScanType(args, log)
+    assert result is ScanType.Ping
+
+
+def test_initargstarget_hostfile(log):
+    with open("hosts.txt", "w", encoding="utf-8") as f:
+        f.write("1.1.1.1\n2.2.2.2\n")
+    args = create_args(host_file="hosts.txt")
+    result = InitArgsTarget(args, log)
+    assert result == ["1.1.1.1", "2.2.2.2"]
+
+
+def test_initargsmode_evade_requires_root(monkeypatch, log):
+    args = create_args(mode="evade")
+    monkeypatch.setattr(utils, "is_root", lambda: False)
+    result = InitArgsMode(args, log)
+    assert result is ScanMode.Normal
+
+
+def test_initargsmode_noise(monkeypatch, log):
+    args = create_args(mode="noise")
+    result = InitArgsMode(args, log)
+    assert result is ScanMode.Noise
+
+
+def test_initreport_email(log):
+    args = create_args(
+        report="email",
+        report_email="user@example.com",
+        report_email_password="pw",
+        report_email_to="to@example.com",
+        report_email_from="from@example.com",
+        report_email_server="smtp.example.com",
+        report_email_server_port=587,
+    )
+    method, obj = InitReport(args, log)
+    from modules.report import ReportType, ReportMail
+
+    assert method is ReportType.EMAIL
+    assert isinstance(obj, ReportMail)
+    assert obj.email == "user@example.com"
+
+
+def test_confirmation_yes(monkeypatch):
+    monkeypatch.setattr(utils, "DontAskForConfirmation", False, raising=False)
+    monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "y")
+    assert Confirmation("?") is True
+
+
+def test_userconfirmation_auto(monkeypatch):
+    monkeypatch.setattr(utils, "DontAskForConfirmation", True, raising=False)
+    assert UserConfirmation() == (True, True, True)
+
+
+def test_gethosts_no_hosts():
+    console = Console(record=True)
+    with pytest.raises(SystemExit):
+        GetHostsToScan([], console)
+
+
+def test_saveoutput_html(tmp_path):
+    console = Console(record=True)
+    console.print("test")
+    out = tmp_path / "out"
+    SaveOutput(console, "html", None, str(out))
+    assert os.path.exists(str(out) + ".html")
+
+
+def test_get_terminal_width():
+    width = get_terminal_width()
+    assert isinstance(width, int) and width > 0


### PR DESCRIPTION
## Summary
- add tests for argument parsing, scan modes, and reporting utilities
- cover AutoScanner helper methods and mocked scan flow
- test logging banners and webhook/email report logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896568185e0832d971a5b4ec13bde7d