### PR TITLE
Pin exact dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-requests
-rich
-python-nmap
-bs4
-distro
+requests==2.32.4
+rich==14.1.0
+python-nmap==0.7.1
+bs4==0.0.2
+distro==1.9.0


### PR DESCRIPTION
## Summary
- Pin requests, rich, python-nmap, bs4, and distro to explicit versions in requirements.txt

## Testing
- `python -m pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_689655dd49a8832d8bedefeff379249c