### PR TITLE
Organize crawler imports and verify basic crawling

### DIFF
--- a/modules/web/crawler.py
+++ b/modules/web/crawler.py
@@ -1,8 +1,8 @@
 from bs4 import BeautifulSoup
-from modules.random_user_agent import random_user_agent
-from requests import get
-from requests import packages
+from requests import get, packages
 from requests.exceptions import ConnectionError
+
+from modules.random_user_agent import random_user_agent
 
 
 packages.urllib3.disable_warnings()


### PR DESCRIPTION
## Summary
- organize requests imports and ensure BeautifulSoup import is in crawler
- verify crawler performs a basic crawl

## Testing
- `pytest -q`
- `python - <<'PY'
import threading, http.server, socketserver, tempfile, pathlib, os
from modules.web.crawler import crawl
from modules.logger import Logger
from rich.console import Console

html_index = "<html><body><a href='page1.html'>Page1</a><a href='/page2.html'>Page2</a><a href='http://external.com'>External</a></body></html>"
html_page1 = "<html><body><a href='page1_sub.html'>Sub</a></body></html>"
html_page1_sub = "<html></html>"
html_page2 = "<html></html>"

with tempfile.TemporaryDirectory() as tmpdir:
    pathlib.Path(tmpdir, 'index.html').write_text(html_index)
    pathlib.Path(tmpdir, 'page1.html').write_text(html_page1)
    pathlib.Path(tmpdir, 'page1_sub.html').write_text(html_page1_sub)
    pathlib.Path(tmpdir, 'page2.html').write_text(html_page2)

    os.chdir(tmpdir)
    handler = http.server.SimpleHTTPRequestHandler
    httpd = socketserver.TCPServer(('localhost', 8000), handler)
    threading.Thread(target=httpd.serve_forever, daemon=True).start()

    console = Console()
    log = Logger(console)
    urls = crawl('http://localhost:8000', log)
    print('Crawled URLs:', sorted(urls))

    httpd.shutdown()
PY`


------
https://chatgpt.com/codex/tasks/task_e_6897a5c6ad0c832d8f4da38fc4b8f2fe