### PR TITLE
Refactor web vulnerability tests to plugin architecture

### DIFF
--- a/modules/web/plugins/__init__.py
+++ b/modules/web/plugins/__init__.py
@@ -1,0 +1,9 @@
+class WebTest:
+    """Interface for web vulnerability plugins."""
+
+    def __init__(self, log, console) -> None:
+        self.log = log
+        self.console = console
+
+    def run(self, url):
+        raise NotImplementedError

--- a/modules/web/plugins/lfi.py
+++ b/modules/web/plugins/lfi.py
@@ -1,3 +1,4 @@
+from modules.web.plugins import WebTest
 from requests import get
 from requests import packages
 from requests.exceptions import ConnectionError
@@ -5,10 +6,9 @@ from requests.exceptions import ConnectionError
 
 packages.urllib3.disable_warnings()
 
-class TestLFI:
+class TestLFI(WebTest):
     def __init__(self, log, console) -> None:
-        self.log = log
-        self.console = console
+        super().__init__(log, console)
         self.tested_urls = []
         self.lfi_tests = [
             r"../../../../../etc/passwd",
@@ -91,7 +91,7 @@ class TestLFI:
                         )
                         break
 
-    def test_lfi(self, url) -> None:
+    def run(self, url) -> None:
         """
         Test for LFI
         """

--- a/modules/web/plugins/sqli.py
+++ b/modules/web/plugins/sqli.py
@@ -1,3 +1,4 @@
+from modules.web.plugins import WebTest
 from requests import get
 from requests import packages
 from requests.exceptions import ConnectionError
@@ -5,10 +6,9 @@ from requests.exceptions import ConnectionError
 
 packages.urllib3.disable_warnings()
 
-class TestSQLI:
+class TestSQLI(WebTest):
     def __init__(self, log, console) -> None:
-        self.log = log
-        self.console = console
+        super().__init__(log, console)
         self.tested_urls = []
         self.sqli_test = "'1"
         self.sql_dbms_errors = [
@@ -51,7 +51,7 @@ class TestSQLI:
                         )
                         break
 
-    def test_sqli(self, url) -> None:
+    def run(self, url) -> None:
         """
         Test for SQLI
         """

--- a/modules/web/plugins/xss.py
+++ b/modules/web/plugins/xss.py
@@ -1,3 +1,4 @@
+from modules.web.plugins import WebTest
 from random import choices, randint
 from string import ascii_letters
 
@@ -8,10 +9,9 @@ from requests.exceptions import ConnectionError
 
 packages.urllib3.disable_warnings()
 
-class TestXSS:
+class TestXSS(WebTest):
     def __init__(self, log, console) -> None:
-        self.log = log
-        self.console = console
+        super().__init__(log, console)
         self.tested_urls = []
         self.xss_test = [
             r"<script>alert('PAYLOAD')</script>",
@@ -71,7 +71,7 @@ class TestXSS:
                         )
                         break
 
-    def test_xss(self, url) -> None:
+    def run(self, url) -> None:
         """
         Tets for XSS
         """


### PR DESCRIPTION
## Summary
- Introduce `WebTest` interface for web vulnerability plugins
- Dynamically load web test plugins and execute via common `run` method
- Convert existing LFI/SQLI/XSS checks into plugins

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897a5e57bc4832dbec2411861936faa