### PR TITLE
Add CVE result caching in searchvuln

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 modules/__pycache__
 modules/web/__pycache__
 venv/*
+modules/data/cve_cache.json


### PR DESCRIPTION
## Summary
- Cache CVE search results by keyword and persist them to JSON
- Reuse cached results before querying NIST API
- Ignore generated cache file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897a5f32100832d93a4a8eac54bb4c9